### PR TITLE
Fix dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,10 @@ spirelm @ git+https://github.com/utter-project/SpireLM@e0b3744
 sentencepiece
 protobuf
 accelerate
+nemo
+hydra-core
+whisper
+nemo-asr
+nemo_toolkit[all]
+Cython
+packaging


### PR DESCRIPTION
Current set of dependencies is not enough to run infer-loop.sh:

I followed the instructions, but I kept getting ModuleNotFound. Removed the venv and tried from a clean one again as follows:
```bash
pip install -r requirements.txt
pip uninstall nemo-toolkit
pip install git+https://github.com/NVIDIA/NeMo.git@main
./infer-loop.sh | bash -v
```
After each run of the infer-loop and inspections of outputs/canary-v2_asr/acl6060-short/en-ru.jsonl.err had to manually install the the following dependencies(all triggered by nemo):

1.     hydra
2.     lightning
3.     nv_one_logger
4.     nv_one_logger_telemetry
5.     nv_one_logger_pytorch_lightning_intgration
6.     lhotse
7.     einops
8.     kaldialign 


To resolve the issue, the required dependencies are updated.