### PR TITLE
Fix tensor conversion to use the actual hardware

### DIFF
--- a/evaluation/metrics/metricx/metric.py
+++ b/evaluation/metrics/metricx/metric.py
@@ -74,9 +74,9 @@ class BaseMetricX():
             tokens["input_ids"] = tokens["input_ids"][:, :-1]
             tokens["attention_mask"] = tokens["attention_mask"][:, :-1]
 
-            # move tokens to cuda device
-            tokens["input_ids"] = tokens["input_ids"].to("cuda")
-            tokens["attention_mask"] = tokens["attention_mask"].to("cuda")
+            # move tokens to the available device
+            tokens["input_ids"] = tokens["input_ids"].to(self.device)
+            tokens["attention_mask"] = tokens["attention_mask"].to(self.device)
 
             with torch.no_grad():
                 outputs = self.model(**tokens)


### PR DESCRIPTION
Fix for identifying and using the actual hardware the metrics are running on. 

I was on CPU's and had to re-run the evals. The fix uses the self.device defined in the constructor to account for the hardware.